### PR TITLE
[feat] custom response

### DIFF
--- a/src/main/java/com/slog/domain/Response.java
+++ b/src/main/java/com/slog/domain/Response.java
@@ -1,0 +1,42 @@
+package com.slog.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+
+import com.slog.domain.enums.ResultCode;
+
+import lombok.Getter;
+
+@Getter
+public class Response<T> {
+	private final ResultCode resultCode;
+	private final T data;
+
+	private Response(ResultCode resultCode, T data) {
+		this.resultCode = resultCode;
+		this.data = data;
+	}
+
+	public static <T> Response<T> success(T data) {
+		return new Response<>(ResultCode.SUCCESS, data);
+	}
+
+	public static <T> Response<T> error(ResultCode resultCode) {
+		return new Response<>(resultCode, null);
+	}
+
+	public static <T> Response<T> error(ResultCode resultCode, T data) {
+		return new Response<>(resultCode, data);
+	}
+
+	public ResponseEntity<Object> toResponseEntity() {
+		Map<String, Object> responseMap = new HashMap<>();
+		responseMap.put("code", resultCode.getCode());
+		responseMap.put("message", resultCode.getMessage());
+		responseMap.put("data", data);
+
+		return ResponseEntity.status(resultCode.getHttpStatus()).body(responseMap);
+	}
+}

--- a/src/main/java/com/slog/domain/enums/ResultCode.java
+++ b/src/main/java/com/slog/domain/enums/ResultCode.java
@@ -1,0 +1,22 @@
+package com.slog.domain.enums;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ResultCode {
+	SUCCESS("200", "OK", HttpStatus.OK),
+	INVALID_ARGUMENT("400", "Bad Request", HttpStatus.BAD_REQUEST),
+	UNAUTHORIZED("401", "Unauthorized", HttpStatus.UNAUTHORIZED),
+	FORBIDDEN("403", "Forbidden", HttpStatus.FORBIDDEN),
+	NOT_FOUND("404", "Not Found", HttpStatus.NOT_FOUND),
+	INTERNAL_SERVER_ERROR("500", "Internal Server Error", HttpStatus.INTERNAL_SERVER_ERROR);
+
+	private final String code;
+	private final String message;
+	private final HttpStatus httpStatus;
+}


### PR DESCRIPTION
1. ResultCode 열거형 클래스 생성
ResultCode 열거형 클래스를 생성하여 응답 코드와 메시지, HTTP 상태 코드를 상수로 정의하였습니다.

2. Response 클래스 생성
Response 클래스를 생성하여 응답 코드, 데이터, HTTP 상태 코드를 멤버 변수로 정의하였습니다. 이 때, 유연한 처리를 위하여 응답 코드와 데이터는 제네릭스를 이용하였습니다.

3. Response 클래스 생성자와 정적 팩토리 메서드 정의
Response 클래스에 대한 생성자와 정적 팩토리 메서드(of 메서드)를 정의했습니다.

4. toResponseEntity 메서드 정의
toResponseEntity 메서드를 정의하여 Response 객체를 ResponseEntity 객체로 변환할 수 있도록 만들었습니다. 이 때, Response 객체를 JSON 형식으로 변환하여 ResponseEntity의 body에 설정하고, HTTP 상태 코드는 ResultCode 클래스에서 가져오도록 하였습니다.