### PR TITLE
feat: custom exception 제작

### DIFF
--- a/src/main/java/com/slog/controller/AuthenticationController.java
+++ b/src/main/java/com/slog/controller/AuthenticationController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.slog.domain.Response;
 import com.slog.domain.dto.AuthenticationRequest;
+import com.slog.exception.SlogAppException;
 import com.slog.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,10 @@ public class AuthenticationController {
 
 	@PostMapping("/authenticate")
 	public Response<String> authenticate(@RequestBody final @Valid AuthenticationRequest request) {
-		return Response.success(memberService.authentication(request));
+		try {
+			return Response.success(memberService.authentication(request));
+		} catch (SlogAppException e) {
+			return Response.error(e.getErrorCode().getResultCode(), e.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/slog/domain/Response.java
+++ b/src/main/java/com/slog/domain/Response.java
@@ -33,8 +33,8 @@ public class Response<T> {
 
 	public ResponseEntity<Object> toResponseEntity() {
 		Map<String, Object> responseMap = new HashMap<>();
-		responseMap.put("code", resultCode.getCode());
-		responseMap.put("message", resultCode.getMessage());
+		responseMap.put("code", resultCode.getHttpStatus().value());
+		responseMap.put("message", resultCode.getHttpStatus().getReasonPhrase());
 		responseMap.put("data", data);
 
 		return ResponseEntity.status(resultCode.getHttpStatus()).body(responseMap);

--- a/src/main/java/com/slog/domain/enums/ResultCode.java
+++ b/src/main/java/com/slog/domain/enums/ResultCode.java
@@ -9,14 +9,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ResultCode {
-	SUCCESS("200", "OK", HttpStatus.OK),
-	INVALID_ARGUMENT("400", "Bad Request", HttpStatus.BAD_REQUEST),
-	UNAUTHORIZED("401", "Unauthorized", HttpStatus.UNAUTHORIZED),
-	FORBIDDEN("403", "Forbidden", HttpStatus.FORBIDDEN),
-	NOT_FOUND("404", "Not Found", HttpStatus.NOT_FOUND),
-	INTERNAL_SERVER_ERROR("500", "Internal Server Error", HttpStatus.INTERNAL_SERVER_ERROR);
+	SUCCESS(HttpStatus.OK),
+	INVALID_ARGUMENT(HttpStatus.BAD_REQUEST),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED),
+	FORBIDDEN(HttpStatus.FORBIDDEN),
+	NOT_FOUND( HttpStatus.NOT_FOUND),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR),
+	CONFLICT(HttpStatus.CONFLICT);
 
-	private final String code;
-	private final String message;
 	private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/slog/exception/DatabaseException.java
+++ b/src/main/java/com/slog/exception/DatabaseException.java
@@ -1,0 +1,20 @@
+package com.slog.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class DatabaseException extends RuntimeException {
+
+	private ErrorCode errorCode;
+	private int sqlErrorCode;
+
+	public DatabaseException(ErrorCode errorCode, int sqlErrorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+		this.sqlErrorCode = sqlErrorCode;
+	}
+}

--- a/src/main/java/com/slog/exception/ErrorCode.java
+++ b/src/main/java/com/slog/exception/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.slog.exception;
+
+import com.slog.domain.enums.ResultCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public enum ErrorCode {
+  NOT_FOUND(ResultCode.NOT_FOUND, "해당 페이지를 찾을 수 없습니다."),
+  DUPLICATED_MEMBER_NAME(ResultCode.CONFLICT, "이미 존재하고 있는 사용자입니다."),
+  MEMBER_NOT_FOUND(ResultCode.NOT_FOUND, "존재하지 않는 사용자입니다."),
+  INVALID_PASSWORD(ResultCode.UNAUTHORIZED, "잘못된 비밀번호입니다."),
+  INCONSISTENT_INFORMATION(ResultCode.CONFLICT, "일치하지 않는 정보입니다."),
+  REJECT_PASSWORD(ResultCode.CONFLICT, "비밀번호는 8~16자입니다."),
+  UNKNOWN_ERROR(ResultCode.INVALID_ARGUMENT, "알 수 없는 에러가 발생했습니다."),
+  DATABASE_ERROR(ResultCode.INTERNAL_SERVER_ERROR, "DB에러"),
+  NOT_EXIST_INQUIRY_TITLE(ResultCode.INVALID_ARGUMENT, "제목이 없습니다."),
+  NOT_EXIST_INQUIRY_CONTENT(ResultCode.INVALID_ARGUMENT, "내용이 없습니다."),
+
+  EXPIRED_TOKEN(ResultCode.UNAUTHORIZED, "만료된 토큰입니다."),
+  INVALID_TOKEN(ResultCode.UNAUTHORIZED, "잘못된 토큰입니다."),
+  INVALID_PERMISSION(ResultCode.UNAUTHORIZED, "사용자가 권한이 없습니다."),
+  NOT_EXIST_TOKEN(ResultCode.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+  NOT_ENOUGH_POINTS(ResultCode.INVALID_ARGUMENT, "포인트가 부족합니다."),
+  ;
+
+  private ResultCode resultCode;
+  private String message;
+}

--- a/src/main/java/com/slog/exception/ExceptionManager.java
+++ b/src/main/java/com/slog/exception/ExceptionManager.java
@@ -1,0 +1,34 @@
+package com.slog.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.slog.domain.Response;
+import com.slog.domain.enums.ResultCode;
+
+@RestControllerAdvice
+public class ExceptionManager {
+
+  @ExceptionHandler(SlogAppException.class)
+  public ResponseEntity<?> SlogAppExceptionHandler(SlogAppException e) {
+    Map<String, Object> result = new HashMap<>();
+    result.put("errorCode", e.getErrorCode());
+    result.put("message", e.getMessage());
+    return ResponseEntity.status(e.getErrorCode().getResultCode().getHttpStatus())
+        .body(Response.error(e.getErrorCode().getResultCode(), result));
+  }
+
+  @ExceptionHandler(DatabaseException.class)
+  public ResponseEntity<?> databaseExceptionHandler(DatabaseException e) {
+    Map<String, Object> result = new HashMap<>();
+    result.put("errorCode", e.getErrorCode());
+    result.put("sqlErrorCode", e.getSqlErrorCode());
+    result.put("message", e.getMessage());
+    return ResponseEntity.status(e.getErrorCode().getResultCode().getHttpStatus())
+        .body(Response.error(ResultCode.valueOf(e.getErrorCode().getResultCode().getHttpStatus().name()), result));
+  }
+}

--- a/src/main/java/com/slog/exception/SlogAppException.java
+++ b/src/main/java/com/slog/exception/SlogAppException.java
@@ -1,0 +1,18 @@
+package com.slog.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SlogAppException extends RuntimeException {
+
+    private ErrorCode errorCode;
+
+    public SlogAppException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/slog/service/MemberService.java
+++ b/src/main/java/com/slog/service/MemberService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 
 import com.slog.config.JwtUtils;
 import com.slog.domain.dto.AuthenticationRequest;
+import com.slog.exception.ErrorCode;
+import com.slog.exception.SlogAppException;
 import com.slog.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,7 @@ public class MemberService {
 
 	public String authentication(AuthenticationRequest request) {
 		final UserDetails user = memberRepository.findByMemberEmail(request.getEmail())
-			.orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+			.orElseThrow(() -> new SlogAppException(ErrorCode.MEMBER_NOT_FOUND, "존재하지 않는 회원입니다."));
 
 		if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
 			authenticationManager.authenticate(
@@ -34,6 +36,6 @@ public class MemberService {
 			log.info("인증 성공: {}", request.getEmail());
 			return jwtUtils.generateToken(user);
 		}
-		throw new IllegalStateException("인증에 실패하였습니다.");
+		throw new SlogAppException(ErrorCode.INVALID_PASSWORD, "인증에 실패하였습니다.");
 	}
 }


### PR DESCRIPTION
1. resultCode를 필요한 필드만 제외하고 삭제하였습니다.
2. 이에 따라 Response를 수정하였습니다.
3. DatabaseException 클래스 생성. 데이터베이스와 관련된 예외를 처리합니다.
4. ErrorCode 열거형은 애플리케이션의 다양한 에러 상황을 나타내며, 각각에 대한 ResultCode와 에러 메시지를 포함합니다.
5. ExceptionManager 클래스 생성. 각 예외 유형에 대한 처리를 정의하고, 적절한 응답을 반환합니다.
6. SlogAppException 클래스 생성. 애플리케이션 전반에 걸쳐 사용되는 사용자 정의 예외입니다.
7. api에 custom exception을 적용.